### PR TITLE
refactor: restrict username validation to alphanumeric and hyphens only

### DIFF
--- a/apps/user/models.py
+++ b/apps/user/models.py
@@ -1,11 +1,22 @@
 from django.contrib.auth.models import AbstractBaseUser, BaseUserManager
 from django.db import models
+from django.core.validators import RegexValidator
 
 from .enums import Language, Visibility
 
 
 class User(AbstractBaseUser):
-    username = models.CharField(max_length=50, unique=True)
+    username = models.CharField(
+        max_length=50,
+        unique=True,
+        validators=[
+            RegexValidator(
+                regex=r'^[a-zA-Z0-9-]*$',
+                message='Username must be alphanumeric or contain hyphens',
+                code='invalid_username'
+            ),
+        ]
+    )
 
     email = models.EmailField(max_length=255, unique=True)
 


### PR DESCRIPTION
Es valido -> a-z, A-Z, 0-9 y guiones